### PR TITLE
Enable out-of-tree builds.  autoconfigure a clock for clock_gettime. …

### DIFF
--- a/ctable_server/Makefile.in
+++ b/ctable_server/Makefile.in
@@ -187,6 +187,9 @@ binaries: $(BINARIES)
 
 libraries: pkgIndex.tcl
 
+$(PKG_TCL_SOURCES):
+	cp -f $(srcdir)/$@ $@
+
 pkgIndex.tcl: $(PKG_TCL_SOURCES)
 	echo "pkg_mkIndex . $(PKG_TCL_SOURCES)" | $(TCLSH_PROG)
 
@@ -380,6 +383,10 @@ install-lib-binaries:
 	    destp=`basename $$p`; \
 	    echo " Install $$destp $(DESTDIR)$(pkglibdir)/$$destp"; \
 	    $(INSTALL_DATA) $(srcdir)/$$p $(DESTDIR)$(pkglibdir)/$$destp; \
+	  elif test -f $$p; then \
+	    destp=`basename $$p`; \
+	    echo " Install $$destp $(DESTDIR)$(pkglibdir)/$$destp"; \
+	    $(INSTALL_DATA) $$p $(DESTDIR)$(pkglibdir)/$$destp; \
 	  fi; \
 	done
 	@if test true -o "x$(SHARED_BUILD)" = "x1"; then \

--- a/ctables/Makefile.in
+++ b/ctables/Makefile.in
@@ -183,6 +183,9 @@ all: binaries libraries doc
 # of the Makefile, in the "BINARIES" variable.
 #========================================================================
 
+$(PKG_TCL_SOURCES):
+	cp -f $(srcdir)/$@ $@$
+
 binaries: $(BINARIES)
 
 libraries:
@@ -383,6 +386,10 @@ install-lib-binaries:
 	    destp=`basename $$p`; \
 	    echo " Install $$destp $(DESTDIR)$(pkglibdir)/$$destp"; \
 	    $(INSTALL_DATA) $(srcdir)/$$p $(DESTDIR)$(pkglibdir)/$$destp; \
+	  elif test -f $$p; then \
+	    destp=`basename $$p`; \
+	    echo " Install $$destp $(DESTDIR)$(pkglibdir)/$$destp"; \
+	    $(INSTALL_DATA) $$p $(DESTDIR)$(pkglibdir)/$$destp; \
 	  fi; \
 	done
 	@if test "x$(SHARED_BUILD)" = "x1"; then \

--- a/ctables/configure.in
+++ b/ctables/configure.in
@@ -137,6 +137,32 @@ CTABLES_CFLAGS=""
 AC_CHECK_HEADER(sys/limits.h,[CTABLES_CFLAGS="$CTABLES_CFLAGS -DHAVE_SYS_LIMITS_H=1"])
 AC_CHECK_HEADER(netinet/ether.h,[CTABLES_CFLAGS="$CTABLES_CFLAGS -DHAVE_NETINET_ETHER_H=1"])
 
+AC_CHECK_DECL(CLOCK_VIRTUAL ,[
+	CTABLES_CFLAGS="$CTABLES_CFLAGS -DCTABLES_CLOCK=CLOCK_VIRTUAL"
+] ,[
+
+	AC_CHECK_DECL(CLOCK_PROCESS_CPUTIME_ID ,[
+		CTABLES_CFLAGS="$CTABLES_CFLAGS -DCTABLES_CLOCK=CLOCK_PROCESS_CPUTIME_ID"
+	] ,[
+
+		AC_CHECK_DECL(CLOCK_MONOTONIC ,[
+			CTABLES_CFLAGS="$CTABLES_CFLAGS -DCTABLES_CLOCK=CLOCK_MONOTONIC"
+		] ,[
+
+			AC_CHECK_DECL(CLOCK_REALTIME ,[
+				CTABLES_CFLAGS="$CTABLES_CFLAGS -DCTABLES_CLOCK=CLOCK_REALTIME"
+			] ,[
+				AC_MSG_ERROR([No clock found.  Tried CLOCK_VIRTUAL, CLOCK_PROCESS_CPUTIME_ID, CLOCK_MONOTONIC, and CLOCK_REALTIME])
+			] ,[[#include <time.h>]])
+
+		] ,[[#include <time.h>]])
+
+	] ,[[#include <time.h>]])
+
+] ,[[#include <time.h>]])
+
+
+
 
 # Check for Boost.
 # If you are missing Boost, try installing the devel/boost-libs or boost-devel package, or downloading from http://www.boost.org/

--- a/ctables/ctable.h
+++ b/ctables/ctable.h
@@ -18,7 +18,9 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+/*
 #include <net/ethernet.h>
+*/
 
 #ifdef HAVE_NETINET_ETHER_H
 #include <netinet/ether.h>

--- a/ctables/ctable_search.c
+++ b/ctables/ctable_search.c
@@ -2405,7 +2405,7 @@ ctable_performance_callback (Tcl_Interp *interp, CTable *ctable, Tcl_Obj *CONST 
 
     // calculate elapsed cpu
 
-    clock_gettime (CLOCK_VIRTUAL, &endTimeSpec);
+    clock_gettime (CTABLES_CLOCK, &endTimeSpec);
     ctable_elapsed_time (startTimeSpec, &endTimeSpec, &elapsedTimeSpec);
     cpu = (elapsedTimeSpec.tv_sec + (elapsedTimeSpec.tv_nsec / 1000000000.0));
 
@@ -2509,7 +2509,7 @@ ctable_SetupAndPerformSearch (Tcl_Interp *interp, Tcl_Obj *CONST objv[], int obj
 
 
     if (ctable->performanceCallbackEnable) {
-	clock_gettime (CLOCK_VIRTUAL, &startTimeSpec);
+	clock_gettime (CTABLES_CLOCK, &startTimeSpec);
     }
 
     // flag this search in progress

--- a/ctables/gentable.tcl
+++ b/ctables/gentable.tcl
@@ -5846,7 +5846,7 @@ proc compile {fileFragName version} {
     # Keep sysconfig(ccflags) from overriding optimization level
     regsub -all { -O[0-9] } " $sysconfig(ccflags) " { } sysconfig(ccflags)
 
-    myexec "$sysconfig(cxx) $sysString $optflag $dbgflag $sysconfig(ldflags) $sysconfig(ccflags) -I$include $sysconfig(warn) $pgString $cassString $stubString $memDebugString -c $sourceFile -o $objFile"
+    myexec "$sysconfig(cxx) $sysString $optflag $dbgflag $sysconfig(ldflags) $sysconfig(ccflags) -I$include $sysconfig(warn) $pgString $cassString $stubString $memDebugString -c $sourceFile -o $objFile 2>@stderr"
 
     set ld_cmd "$sysconfig(cxxld) $dbgflag -o $targetPath/lib${fileFragName}$sysconfig(shlib) $objFile"
 
@@ -5872,7 +5872,7 @@ proc compile {fileFragName version} {
     }
 
     append ld_cmd " $sysconfig(ldflags) $stub"
-    myexec $ld_cmd
+    myexec "$ld_cmd 2>@stderr"
 
     if {$withSubdir} {
 	set pkg_args [list $buildPath */*.tcl */*[info sharedlibextension]]

--- a/stapi/Makefile.in
+++ b/stapi/Makefile.in
@@ -187,6 +187,10 @@ binaries: $(BINARIES)
 
 libraries: pkgIndex.tcl
 
+$(PKG_TCL_SOURCES):
+	mkdir -p $$(dirname $@); \
+	cp -f $(srcdir)/$@ $@
+
 pkgIndex.tcl: $(PKG_TCL_SOURCES)
 	echo "pkg_mkIndex . $(PKG_TCL_SOURCES)" | $(TCLSH_PROG)
 
@@ -382,6 +386,10 @@ install-lib-binaries:
 	    mkdir -p $(DESTDIR)$(pkglibdir)/`dirname $$p`; \
 	    echo " Install $$p $(DESTDIR)$(pkglibdir)/$$p"; \
 	    $(INSTALL_DATA) $(srcdir)/$$p $(DESTDIR)$(pkglibdir)/$$p; \
+	  elif test -f $$p; then \
+	    mkdir -p $(DESTDIR)$(pkglibdir)/`dirname $$p`; \
+	    echo " Install $$p $(DESTDIR)$(pkglibdir)/$$p"; \
+	    $(INSTALL_DATA) $$p $(DESTDIR)$(pkglibdir)/$$p; \
 	  fi; \
 	done
 	@if test true -o "x$(SHARED_BUILD)" = "x1"; then \


### PR DESCRIPTION
… Modify

myexec to not die on stderr output.  Comment out net/ethernet.h include, which
seems to be unnecessary, and isn't available under Cygwin.
