### PR TITLE
Add share invalidate command

### DIFF
--- a/ctables/docs/manual/ch08.html
+++ b/ctables/docs/manual/ch08.html
@@ -88,6 +88,9 @@
 <dt>free<dd>
 <p>Returns an estimate of the free memory in the share. This estimate does not count pools, and is calculated by iterating over the free list and the garbage collection pool and adding up the total size of each free or dirty block.</p>
 
+<dt>invalidate<dd>
+<p>Invoke madvise(addr, size, MS_INVALIDATE) on the memory mapped file. By clearing the dirty bits on the pages the OS will not flush dirty pages to the disk backing store at exit. This can ccorrupt the disk image of data.</p>
+
 </dl>
 
 </dl>

--- a/ctables/shared/shared.c
+++ b/ctables/shared/shared.c
@@ -245,6 +245,12 @@ int unmap_file(shm_t   *share)
       delete share->garbage;
     }
     ckfree(share->filename);
+
+#ifndef MAP_NOSYNC
+    // Try to be similar to MAP_NOSYNC
+    madvise(share->share_base, share->managed_shm->get_size(), MS_INVALIDATE);
+#endif
+
     delete share->managed_shm;
 
     ckfree((char*)share);

--- a/ctables/shared/shared.c
+++ b/ctables/shared/shared.c
@@ -245,7 +245,6 @@ int unmap_file(shm_t   *share)
       delete share->garbage;
     }
     ckfree(share->filename);
-
     delete share->managed_shm;
 
     ckfree((char*)share);


### PR DESCRIPTION
Add share invalidate to call madvise MS_INVALIDATE on memory mapped file segment.  The intent is to speed up shutdown by avoiding the synchronization of dirty pages to the backing file.