### PR TITLE
Fixed string default handling.

### DIFF
--- a/ctables/gentable.tcl
+++ b/ctables/gentable.tcl
@@ -774,7 +774,11 @@ variable fixedstringSetSource {
 	if (*stringPtr == *row->$fieldName && strncmp(row->$fieldName, stringPtr, $length) == 0)
 	    return TCL_OK;"]
 [gen_ctable_remove_from_index $fieldName]
-	strncpy (row->$fieldName, stringPtr, $length);
+	if(len < $length) {
+		strncpy (row->$fieldName, "[cquote $default]", $length);
+		strncpy (row->$fieldName, stringPtr, len);
+	} else
+		strncpy (row->$fieldName, stringPtr, $length);
 [gen_ctable_insert_into_index $fieldName]
 	break;
       }

--- a/ctables/tests/Makefile.in
+++ b/ctables/tests/Makefile.in
@@ -42,6 +42,7 @@ maintests:
 	$(TCLSH) index-compare.tcl
 	rm -rf stobj
 	$(TCLSH) index-defaults.tcl
+	$(TCLSH) fixed-defaults.tcl
 	$(TCLSH) filter.tcl
 	$(TCLSH) filter2.tcl
 	$(TCLSH) tclobj.tcl

--- a/ctables/tests/fixed-default.tcl
+++ b/ctables/tests/fixed-default.tcl
@@ -1,0 +1,38 @@
+#
+# fixed string default test
+#
+# $Id$
+#
+
+source test_common.tcl
+
+package require ctable
+
+CExtension fixed_defaults 1.0 {
+
+CTable fixedStrings {
+    int noid
+    fixedstring single 1 notnull 1 default "-"
+    fixedstring triple 3 notnull 1 default "---"
+}
+
+}
+
+package require Fixed_defaults 1.0
+
+fixedStrings create t
+
+proc tt {cmd expected} {
+	eval $cmd
+	set result [t array_get 1]
+	if {"$result" ne "$expected"} {
+		error "Command [list $cmd] expected [list $expected] got [list $result]"
+	}
+}
+
+tt {t set 1 noid 1} {noid 1 single - triple ---}
+tt {t set 1 single a triple abc} {noid 1 single a triple abc}
+tt {t set 1 single ""} {noid 1 single - triple abc}
+tt {t set 1 triple ""} {noid 1 single - triple ---}
+tt {t set 1 triple "a"} {noid 1 single - triple a--}
+

--- a/ctables/tests/index-test-proc.tcl
+++ b/ctables/tests/index-test-proc.tcl
@@ -5,6 +5,7 @@ proc test_index {table args} {
   if {"$table" == "-v"} {
     set table [lindex $args 0]
     set args [lrange $args 1 end]
+    set verbose 1
   }
   if {$verbose} {puts -nonewline [info level 0]...; flush stdout}
   set comp [list $args]


### PR DESCRIPTION
Assignments to fixed strings shorter than the declared length are padded with the default string.