### PR TITLE
Fix nested search

### DIFF
--- a/ctables/command-body.c-subst
+++ b/ctables/command-body.c-subst
@@ -636,20 +636,20 @@ int ${table}ObjCmd (ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CON
 	      break;
 	  }
 #endif
-	  Tcl_AppendResult(interp, "Not a shared table.\n", NULL);
+	  Tcl_AppendResult(interp, "Not a shared table.", NULL);
 	  Tcl_SetErrorCode (interp, "speedtables", "not_a_shared_table", NULL);
 	  return TCL_ERROR;
       }
 
       case OPT_DELETE: {
 	if(ctable->cursors) {
-	    Tcl_AppendResult(interp, "Can not delete while cursors are active.\n", NULL);
+	    Tcl_AppendResult(interp, "Can not delete while cursors are active.", NULL);
 	    Tcl_SetErrorCode (interp, "speedtables", "no_delete_with_cursors", NULL);
 	    return TCL_ERROR;
 	}
 
 	if(ctable->searching) {
-	    Tcl_AppendResult(interp, "Can not delete from inside search.\n", NULL);
+	    Tcl_AppendResult(interp, "Can not delete from inside search.", NULL);
 	    Tcl_SetErrorCode (interp, "speedtables", "no_delete_inside_search", NULL);
 	    return TCL_ERROR;
 	}

--- a/ctables/ctable_search.c
+++ b/ctables/ctable_search.c
@@ -2632,11 +2632,12 @@ ctable_SetupAndPerformSearch (Tcl_Interp *interp, Tcl_Obj *CONST objv[], int obj
 #endif
 
     // flag this search in progress
+    int prev_state = ctable->searching;
     ctable->searching = 1;
 
     result = ctable_SetupSearch (interp, ctable, objv, objc, &search, indexField);
     if (result == TCL_ERROR) {
-        ctable->searching = 0;
+        ctable->searching = prev_state;
         return TCL_ERROR;
     }
 
@@ -2655,7 +2656,7 @@ ctable_SetupAndPerformSearch (Tcl_Interp *interp, Tcl_Obj *CONST objv[], int obj
 
     ctable_TeardownSearch (&search);
 
-    ctable->searching = 0;
+    ctable->searching = prev_state;
 
 #ifdef CTABLES_CLOCK
     if (ctable->performanceCallbackEnable) {

--- a/ctables/ctable_search.c
+++ b/ctables/ctable_search.c
@@ -2273,12 +2273,12 @@ ctable_SetupSearch (Tcl_Interp *interp, CTable *ctable, Tcl_Obj *CONST objv[], i
 
 	    if(do_delete) {
 	      if(ctable->cursors) {
-	        Tcl_AppendResult(interp, "Can not delete while cursors are active.\n", NULL);
+	        Tcl_AppendResult(interp, "Can not delete while cursors are active.", NULL);
 	        Tcl_SetErrorCode (interp, "speedtables", "no_delete_with_cursors", NULL);
 	        return TCL_ERROR;
 	      }
 	      if(nested_search) {
-	        Tcl_AppendResult(interp, "Can not delete in nested search.\n", NULL);
+	        Tcl_AppendResult(interp, "Can not delete in nested search.", NULL);
 	        Tcl_SetErrorCode (interp, "speedtables", "no_delete_inside_search", NULL);
 	        return TCL_ERROR;
 	      }

--- a/ctables/tests/Makefile.in
+++ b/ctables/tests/Makefile.in
@@ -49,6 +49,7 @@ maintests:
 	$(TCLSH) match-fail-test.tcl
 	$(TCLSH) clean-test.tcl
 	$(TCLSH) cursortest.tcl
+	$(TCLSH) nested-search.tcl
 
 clean:
 	rm -rf stobj

--- a/ctables/tests/nested-search.tcl
+++ b/ctables/tests/nested-search.tcl
@@ -1,0 +1,29 @@
+#
+# $Id$
+#
+
+source test_common.tcl
+
+source searchtest-def.tcl
+
+source dumb-data.tcl
+
+proc boom {} {
+	t search -compare {{= alive 1}} -array a -code {
+		t search -compare [list [list = coolness $a(coolness)]] -array b -code {
+			set target $b(_key)
+		}
+		t delete $target
+	}
+}
+
+if {![catch boom error]} {
+	error "There should have been an eath_shattering kaboom"
+} else {
+	puts [list Got $error]
+	if {"$error" ne "Can not delete from inside search.\n"} {
+		error [list expected "Can not delete from inside search.\\n" got $error]
+	}
+}
+
+puts "Nested search test passed"

--- a/ctables/tests/nested-search.tcl
+++ b/ctables/tests/nested-search.tcl
@@ -21,8 +21,8 @@ if {![catch boom error]} {
 	error "There should have been an eath_shattering kaboom"
 } else {
 	puts [list Got $error]
-	if {"$error" ne "Can not delete from inside search.\n"} {
-		error [list expected "Can not delete from inside search.\\n" got $error]
+	if {"$error" ne "Can not delete from inside search."} {
+		error [list expected "Can not delete from inside search." got $error]
 	}
 }
 

--- a/ctables/tests/test_common.tcl
+++ b/ctables/tests/test_common.tcl
@@ -38,7 +38,7 @@ if {"[info commands memory]" != ""} {
 }
 
     # set to 1 to show compiler commands
-    set showCompilerCommands 1
+    set showCompilerCommands 0
 
     # set to 1 to run various sanity checks on rows
     #set sanityChecks 0


### PR DESCRIPTION
Nested search commands were overwriting the status of the outer search when the inner search was completed.

Save and restore search status and use that information to block the "search ... -delete 1" command as well as the existing block on "$table delete" inside a search operation.