### PR TITLE
Don't re-use skiplists in nested searches.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -18,7 +18,7 @@ dnl	to configure the system for the local environment.
 # so you can encode the package version directly into the source files.
 #-----------------------------------------------------------------------
 
-AC_INIT([speedtables], [1.13.5])
+AC_INIT([speedtables], [1.13.6])
 
 #--------------------------------------------------------------------
 # Call TEA_INIT as the first TEA_ macro to set up initial vars.

--- a/ctable_server/configure.in
+++ b/ctable_server/configure.in
@@ -18,7 +18,7 @@ dnl	to configure the system for the local environment.
 # so you can encode the package version directly into the source files.
 #-----------------------------------------------------------------------
 
-AC_INIT([ctable_server], [1.13.5])
+AC_INIT([ctable_server], [1.13.6])
 
 #--------------------------------------------------------------------
 # Call TEA_INIT as the first TEA_ macro to set up initial vars.

--- a/ctable_server/ctable_client.tcl
+++ b/ctable_server/ctable_client.tcl
@@ -621,6 +621,6 @@ proc maketable {cttpUrl sock} {
   return [::sttp_buffer::table $cttpUrl]
 }
 
-package provide ctable_client 1.13.5
+package provide ctable_client 1.13.6
 
 # vim: set ts=8 sw=4 sts=4 noet :

--- a/ctable_server/ctable_client_server.tcl
+++ b/ctable_server/ctable_client_server.tcl
@@ -98,6 +98,6 @@ namespace export split_ctable_url join_ctable_url
 
 }
 
-package provide ctable_net 1.13.5
+package provide ctable_net 1.13.6
 
 # vim: set ts=8 sw=4 sts=4 noet :

--- a/ctable_server/ctable_server.tcl
+++ b/ctable_server/ctable_server.tcl
@@ -678,7 +678,7 @@ proc serverdie {{message ""}} {
 
 }
 
-package provide ctable_server 1.13.5
+package provide ctable_server 1.13.6
 
 #get, set, array_get, array_get_with_nulls, exists, delete, count, foreach, sort, type, import, import_postgres_result, export, fields, fieldtype, needs_quoting, names, reset, destroy, statistics, write_tabsep, or read_tabsep
 

--- a/ctable_server/sttp_buffer.tcl
+++ b/ctable_server/sttp_buffer.tcl
@@ -177,6 +177,6 @@ proc table {cttpUrl} {
 
 }
 
-package provide sttp_buffer 1.13.5
+package provide sttp_buffer 1.13.6
 
 # vim: set ts=8 sw=4 sts=4 noet :

--- a/ctables/command-body.c-subst
+++ b/ctables/command-body.c-subst
@@ -648,7 +648,7 @@ int ${table}ObjCmd (ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CON
 	    return TCL_ERROR;
 	}
 
-	if(ctable->searching) {
+	if(ctable->searches) {
 	    Tcl_AppendResult(interp, "Can not delete from inside search.", NULL);
 	    Tcl_SetErrorCode (interp, "speedtables", "no_delete_inside_search", NULL);
 	    return TCL_ERROR;

--- a/ctables/configure.in
+++ b/ctables/configure.in
@@ -18,7 +18,7 @@ dnl	to configure the system for the local environment.
 # so you can encode the package version directly into the source files.
 #-----------------------------------------------------------------------
 
-AC_INIT([ctable], [1.13.5])
+AC_INIT([ctable], [1.13.6])
 
 #--------------------------------------------------------------------
 # Call TEA_INIT as the first TEA_ macro to set up initial vars.

--- a/ctables/ctable.h
+++ b/ctables/ctable.h
@@ -431,6 +431,9 @@ struct CTableSearch {
     // cursor ID and structure
     char                                *cursorName;
     struct cursor                       *cursor;
+
+    // what index is this searching?
+    int                                  searchField;
 };
 
 struct ctable_FieldInfo {

--- a/ctables/ctable.h
+++ b/ctables/ctable.h
@@ -367,6 +367,7 @@ struct CTableSearchFilter {
 // ctable search struct - this controls everything about a search
 struct CTableSearch {
     struct CTable                       *ctable;
+    struct CTableSearch                 *previousSearch;
     CTableSearchComponent               *components;
     CTableSearchFilter			*filters;
     char                                *pattern;
@@ -512,7 +513,7 @@ struct CTable {
 
     int                                  autoRowNumber;
     int                                  destroying;
-    int					 searching;
+    CTableSearch			*searches;
     char				*nullKeyValue;
 #ifdef WITH_SHARED_TABLES
     int					 was_locked;

--- a/ctables/ctable_search.c
+++ b/ctables/ctable_search.c
@@ -1544,6 +1544,17 @@ restart_search:
 		}
 	    }
 
+	    // If we have previous searches, walk back through the previous searches to see if we're already using
+	    // this field
+	    for(s = search->previousSearch; s; s = s->previousSearch) {
+		if(s->searchField == field) {
+		    break;
+		}
+	    }
+	    if(s) {
+		continue;
+	    }
+
 	    score = skipTypes[comparisonType].score;
 
 	    // Prefer to avoid sort
@@ -1555,6 +1566,7 @@ restart_search:
 
 	    // Got a new best candidate, save the world.
 	    skipField = field;
+	    search->searchField = field;
 
 	    skipNext  = skipTypes[comparisonType].skipNext;
 	    skipStart = skipTypes[comparisonType].skipStart;
@@ -1605,6 +1617,7 @@ restart_search:
 	        break;
         }
     }
+
 
     // if we're sorting on the field we're searching, AND we can eliminate
     // the sort because we know we're walking in order, then eliminate the
@@ -2083,6 +2096,7 @@ ctable_SetupSearch (Tcl_Interp *interp, CTable *ctable, Tcl_Obj *CONST objv[], i
     search->offsetLimit = search->offset + search->limit;
     search->cursorName = NULL;
     search->cursor = NULL;
+    search->searchField = -1;
 
     // Give each search a unique non-zero sequence number
     if(++staticSequence == 0) ++staticSequence;

--- a/ctables/ctable_search.c
+++ b/ctables/ctable_search.c
@@ -1331,6 +1331,8 @@ ctable_PerformSearch (Tcl_Interp *interp, CTable *ctable, CTableSearch *search) 
 
     int			   canUseHash = 1;
 
+    CTableSearch         *s;
+
 #ifdef WITH_SHARED_TABLES
     int			   firstTime = 1;
     int			   locked_cycle = LOST_HORIZON;

--- a/ctables/ctable_search.c
+++ b/ctables/ctable_search.c
@@ -1961,6 +1961,10 @@ if(num_restarts == 0) fprintf(stderr, "%d: loop restart: loop_cycle=%ld; row->_r
   // We only jump to this on success, so we got to the end of the loop
   // or we broke out of it early
   search_complete:
+
+    // We're no longer walking a skiplist, so make a note of that so it can be re-used.
+    search->searchField = -1;
+
     switch (ctable_PostSearchCommonActions (interp, ctable, search)) {
 	case TCL_ERROR: {
 	    finalResult = TCL_ERROR;

--- a/ctables/ctable_search.c
+++ b/ctables/ctable_search.c
@@ -1337,13 +1337,6 @@ ctable_PerformSearch (Tcl_Interp *interp, CTable *ctable, CTableSearch *search) 
     int			   num_restarts = 0;
 
     jsw_skip_t   	  *skipListCopy = NULL;
-
-    // Nested searches need to walk the hash table and there's no hash table in shared reader tables.
-    if(ctable->share_type == CTABLE_SHARED_READER && search->previousSearch) {
-	Tcl_AppendResult (interp, "can't perform nested search with shared tables", (char *) NULL);
-	finalResult = TCL_ERROR;
-	goto clean_and_return;
-    }
 #endif
 
     if (search->writingTabsepIncludeFieldNames) {
@@ -1454,11 +1447,6 @@ restart_search:
 
     // If there's no components in the search, make sure the index is NONE
     if(!search->nComponents) {
-	search->reqIndexField = CTABLE_SEARCH_INDEX_NONE;
-    }
-
-    // If it's a nested search, you have to use the hash table
-    if(search->previousSearch) {
 	search->reqIndexField = CTABLE_SEARCH_INDEX_NONE;
     }
 

--- a/ctables/template.c-subst
+++ b/ctables/template.c-subst
@@ -249,7 +249,7 @@ ${table}MetaObjCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj 
 	    ctable->count = 0;
 	    ctable->autoRowNumber = 0;
 	    ctable->destroying = 0;
-	    ctable->searching = 0;
+	    ctable->searches = NULL;
 	    ctable->nullKeyValue = NULL;
 	    ctable->cursors = NULL;
 #ifdef WITH_SHARED_TABLES

--- a/stapi/client/cass.tcl
+++ b/stapi/client/cass.tcl
@@ -1236,6 +1236,6 @@ namespace eval ::stapi {
   }
 }
 
-package provide st_client_cassandra 1.13.5
+package provide st_client_cassandra 1.13.6
 
 # vim: set ts=8 sw=4 sts=4 noet :

--- a/stapi/client/client.tcl
+++ b/stapi/client/client.tcl
@@ -100,6 +100,6 @@ namespace eval ::stapi {
   register package connect_package
 }
 
-package provide st_client 1.13.5
+package provide st_client 1.13.6
 
 # vim: set ts=8 sw=4 sts=4 noet :

--- a/stapi/client/extend.tcl
+++ b/stapi/client/extend.tcl
@@ -395,7 +395,7 @@ namespace eval ::stapi {
   namespace import ::stapi::extend::*
 }
 
-package provide stapi_extend 1.13.5
+package provide stapi_extend 1.13.6
 
 
 # vim: set ts=8 sw=4 sts=4 noet :

--- a/stapi/client/pgsql.tcl
+++ b/stapi/client/pgsql.tcl
@@ -952,6 +952,6 @@ namespace eval ::stapi {
   }
 }
 
-package provide st_client_postgres 1.13.5
+package provide st_client_postgres 1.13.6
 
 # vim: set ts=8 sw=4 sts=4 noet :

--- a/stapi/client/shared.tcl
+++ b/stapi/client/shared.tcl
@@ -115,6 +115,6 @@ namespace eval ::stapi {
   }
 }
 
-package provide st_shared 1.13.5
+package provide st_shared 1.13.6
 
 # vim: set ts=8 sw=4 sts=4 noet :

--- a/stapi/client/uri.tcl
+++ b/stapi/client/uri.tcl
@@ -40,6 +40,6 @@ namespace eval stapi {
 
 }
 
-package provide st_client_uri 1.13.5
+package provide st_client_uri 1.13.6
 
 # vim: set ts=8 sw=4 sts=4 noet :

--- a/stapi/configure.in
+++ b/stapi/configure.in
@@ -18,7 +18,7 @@ dnl	to configure the system for the local environment.
 # so you can encode the package version directly into the source files.
 #-----------------------------------------------------------------------
 
-AC_INIT([stapi], [1.13.5])
+AC_INIT([stapi], [1.13.6])
 
 #--------------------------------------------------------------------
 # Call TEA_INIT as the first TEA_ macro to set up initial vars.

--- a/stapi/copy.tcl
+++ b/stapi/copy.tcl
@@ -167,5 +167,5 @@ namespace eval ::stapi {
   }
 }
 
-package provide st_postgres 1.13.5
+package provide st_postgres 1.13.6
 

--- a/stapi/debug.tcl
+++ b/stapi/debug.tcl
@@ -54,4 +54,4 @@ namespace eval ::stapi {
   }
 }
 
-package provide st_debug 1.13.5
+package provide st_debug 1.13.6

--- a/stapi/display/display.tcl
+++ b/stapi/display/display.tcl
@@ -2576,5 +2576,5 @@ catch { ::itcl::delete class ::STDisplayField_boolean }
 
 } ; ## ::itcl::class ::STDisplayField_boolean
 
-package provide st_display 1.13.5
+package provide st_display 1.13.6
 

--- a/stapi/display/test.tcl
+++ b/stapi/display/test.tcl
@@ -29,4 +29,4 @@ proc stapi_display_test {} {
   }
 }
 
-package provide st_display_test 1.13.5
+package provide st_display_test 1.13.6

--- a/stapi/pgsql.tcl
+++ b/stapi/pgsql.tcl
@@ -379,4 +379,4 @@ namespace eval ::stapi {
   }
 }
 
-package provide st_postgres 1.13.5
+package provide st_postgres 1.13.6

--- a/stapi/server/lock.tcl
+++ b/stapi/server/lock.tcl
@@ -185,4 +185,4 @@ namespace eval ::stapi {
   }
 }
 
-package provide st_locks 1.13.5
+package provide st_locks 1.13.6

--- a/stapi/server/server.tcl
+++ b/stapi/server/server.tcl
@@ -1279,4 +1279,4 @@ namespace eval ::stapi {
   }
 }
 
-package provide st_server 1.13.5
+package provide st_server 1.13.6

--- a/stapi/stapi.tcl
+++ b/stapi/stapi.tcl
@@ -2,5 +2,5 @@
 
 package require st_client
 
-package provide stapi 1.13.5
+package provide stapi 1.13.6
 

--- a/update_ver.sh
+++ b/update_ver.sh
@@ -2,7 +2,7 @@
 
 # This script simplifies the process of incrementing all version numbers for a new release.
 
-NEWVER="1.13.5"
+NEWVER="1.13.6"
 
 perl -p -i -e "s/^(AC_INIT\\(\\[[a-z_]+\\],) \\[[0-9.]+\\]/\\1 \\[$NEWVER\\]/" configure.in ctables/configure.in stapi/configure.in ctable_server/configure.in
 


### PR DESCRIPTION
Tracks what skiplists are being searched and avoids using skiplists that are in active use.