### PR TITLE
Don't assume runtime libpq location (and fix other Nix compatibility issues)

### DIFF
--- a/ctables/aclocal.m4
+++ b/ctables/aclocal.m4
@@ -75,8 +75,10 @@ fi
 # Check pg_config for pgsql
 pqinclude=`pg_config --includedir`
 if test -f $pqinclude/libpq-fe.h; then
+pqlibdir=`pg_config --libdir`
 sysconfig_tcl_content="$sysconfig_tcl_content
-set sysconfig(pqinclude) $pqinclude"
+set sysconfig(pqinclude) $pqinclude
+set sysconfig(pqlibdir)  $pqlibdir"
 else
   # Fallback - look for pgsql
   for prefix in $pg_prefixes
@@ -95,7 +97,7 @@ fi
 for prefix in $pg_prefixes
 do
   # there may be multiple installed versions of pgtcl so sort with the highest version first.
-  pg_libdirs=`find $prefix/lib -maxdepth 1 -name "pgtcl*" -type d | sort -rn`
+  pg_libdirs=`find -L $prefix/lib -maxdepth 1 -name "pgtcl*" -type d | sort -rn`
 
   if test -z "$pg_libdirs"; then
      continue

--- a/ctables/gentable.tcl
+++ b/ctables/gentable.tcl
@@ -5716,10 +5716,14 @@ proc compile {fileFragName version} {
 	set pgtcl_libdir $sysconfig(pgtclprefix)
 	set pgtcl_ver $sysconfig(pgtclver)
 	set pgtcl_lib pgtcl$pgtcl_ver
+	set pq_libdir /usr/local/lib
+	if {[info exists sysconfig(pqlibdir)]} {
+	    set pq_libdir $sysconfig(pqlibdir)
+	}
 
 	append ld_cmd " -Wl,-rpath,$pgtcl_libdir"
-	append ld_cmd " -L$pgtcl_libdir"
-	append ld_cmd " -l$pgtcl_lib -L/usr/local/lib -lpq"
+	append ld_cmd " -L$pgtcl_libdir -l$pgtcl_lib"
+	append ld_cmd " -L$pq_libdir -lpq"
     }
 
     if {$withCasstcl} {

--- a/ctables/shared/shared.c
+++ b/ctables/shared/shared.c
@@ -52,7 +52,7 @@ char *ckalloc(size_t size)
 
 static char last_shmem_error[256] = { '\0' };
 void set_last_shmem_error(const char *message) {
-    strncpy(last_shmem_error, message, sizeof(last_shmem_error));
+    strncpy(last_shmem_error, message, sizeof(last_shmem_error) - 1);
 }
 
 const char *get_last_shmem_error() {


### PR DESCRIPTION
This PR makes a few changes in order to add `pgtcl` support to our internal `speedtables` Nix package:

1. Set the `libpq` lib directory with `pg_config`, just like we do for the include directory.
2. Follow symlinks when finding the `pgtcl` directory.
3. Fix a `strncpy` invocation that risks clobbering a string terminator. This triggers a `stringop-truncation` warning for recent versions of `gcc`. If I'm not mistaken, there's [at least one place](https://github.com/flightaware/speedtables/blob/6db1ee836ebb68ef2ce38ced193890a330c44917/ctables/shared/shared.c#L65) where we could have been bitten by this.