### PR TITLE
BCK-6828 Fix casstcl linking in speedtables on FreeBSD

### DIFF
--- a/ctables/aclocal.m4
+++ b/ctables/aclocal.m4
@@ -196,9 +196,9 @@ skipped $prefix no libdirs"
     for dir in $cass_libdirs
     do
       if test -f $dir/casstcl.tcl; then
-	casstclver=`basename $dir | sed s/^casstcl//`
+        casstclver=`sh -c "cd $dir && ls libcasstcl*.so | sed -e 's/^libcasstcl//' -e 's/\.so$//'"`
 	if test -z "$casstclver"; then
-          casstclver=`sh -c "cd $dir && ls libcasstcl*.so | sed -e 's/^libcasstcl//' -e 's/\.so$//'"`
+	  casstclver=`basename $dir | sed s/^casstcl//`
         fi
     msg_debug="$msg_debug
 found casstcl in $dir"

--- a/ctables/aclocal.m4
+++ b/ctables/aclocal.m4
@@ -197,8 +197,8 @@ skipped $prefix no libdirs"
     do
       if test -f $dir/casstcl.tcl; then
         casstclver=`sh -c "cd $dir && ls libcasstcl*.so | sed -e 's/^libcasstcl//' -e 's/\.so$//'"`
-	if test -z "$casstclver"; then
-	  casstclver=`basename $dir | sed s/^casstcl//`
+        if test -z "$casstclver"; then
+          casstclver=`basename $dir | sed s/^casstcl//`
         fi
     msg_debug="$msg_debug
 found casstcl in $dir"

--- a/ctables/aclocal.m4
+++ b/ctables/aclocal.m4
@@ -200,7 +200,6 @@ skipped $prefix no libdirs"
 	if test -z "$casstclver"; then
           casstclver=`sh -c "cd $dir && ls libcasstcl*.so | sed -e 's/^libcasstcl//' -e 's/\.so$//'"`
         fi
-      fi
     msg_debug="$msg_debug
 found casstcl in $dir"
         sysconfig_tcl_content="$sysconfig_tcl_content

--- a/ctables/aclocal.m4
+++ b/ctables/aclocal.m4
@@ -196,7 +196,11 @@ skipped $prefix no libdirs"
     for dir in $cass_libdirs
     do
       if test -f $dir/casstcl.tcl; then
-        casstclver=`sh -c "cd $dir && ls libcasstcl*.so | sed -e 's/^libcasstcl//' -e 's/\.so$//'"`
+	casstclver=`basename $dir | sed s/^casstcl//`
+	if test -z "$casstclver"; then
+          casstclver=`sh -c "cd $dir && ls libcasstcl*.so | sed -e 's/^libcasstcl//' -e 's/\.so$//'"`
+        fi
+      fi
     msg_debug="$msg_debug
 found casstcl in $dir"
         sysconfig_tcl_content="$sysconfig_tcl_content

--- a/ctables/gentable.tcl
+++ b/ctables/gentable.tcl
@@ -5729,7 +5729,9 @@ proc compile {fileFragName version} {
     if {$withCasstcl} {
 	set casstcl_libdir $sysconfig(casstclprefix)
 	set casstcl_ver $sysconfig(casstclver)
-	if {[catch {glob $casstcl_libdir/casstcl$casstcl_ver*}]} {
+	set files ""
+	set caught [catch {glob $casstcl_libdir/libcasstcl$casstcl_ver*} files]
+	if {$caught || ![string length $files]} {
 	    set casstcl_lib casstcl
 	} else {
 	    set casstcl_lib casstcl$casstcl_ver

--- a/ctables/gentable.tcl
+++ b/ctables/gentable.tcl
@@ -5729,8 +5729,11 @@ proc compile {fileFragName version} {
     if {$withCasstcl} {
 	set casstcl_libdir $sysconfig(casstclprefix)
 	set casstcl_ver $sysconfig(casstclver)
-	set casstcl_lib casstcl$casstcl_ver
-	#set casstcl_lib casstcl
+	if {[catch {glob $casstcl_libdir/casstcl$casstcl_ver*}]} {
+	    set casstcl_lib casstcl
+	} else {
+	    set casstcl_lib casstcl$casstcl_ver
+	}
 
 	append ld_cmd " -Wl,-rpath,$casstcl_libdir"
 	append ld_cmd " -L$casstcl_libdir"


### PR DESCRIPTION
Reverse version tests: Check for Linux configuration by default, fall back to FreeBSD.

* Explicitly check for existence of libcasstcl$ver in both aclocal.m4 and gentables.tcl
* If it doesn't exist fall back to directory for version and use -lcasstcl
